### PR TITLE
Improve UX with table layout for form repeaters

### DIFF
--- a/app/Filament/Resources/Customers/Schemas/CustomerForm.php
+++ b/app/Filament/Resources/Customers/Schemas/CustomerForm.php
@@ -59,23 +59,36 @@ class CustomerForm
                             ->reorderable(false)
                             ->minItems(1)
                             ->label('')
-                            ->itemLabel(function (array $state): ?string {
-                                /** @var string|null $label */
-                                $label = $state['label'] ?? null;
-
-                                return $label;
-                            })
                             ->schema([
-                                Grid::make(2)->schema([
-                                    TextInput::make('label')->maxLength(50),
-                                    TextInput::make('line1')->required()->maxLength(120),
-                                    TextInput::make('line2')->maxLength(120),
-                                    TextInput::make('city')->required()->maxLength(80),
-                                    TextInput::make('postcode')->required()->maxLength(10),
-                                    Select::make('state_id')->relationship('state', 'name')->searchable()->preload()->required(),
-                                    TextInput::make('country_code')->default('MY')->maxLength(2),
-                                    Toggle::make('is_primary')->label('Primary')->inline(false),
-                                ]),
+                                TextInput::make('label')
+                                    ->maxLength(50)
+                                    ->placeholder('e.g., Home, Office'),
+                                TextInput::make('line1')
+                                    ->required()
+                                    ->maxLength(120)
+                                    ->label('Address Line 1'),
+                                TextInput::make('line2')
+                                    ->maxLength(120)
+                                    ->label('Address Line 2'),
+                                TextInput::make('city')
+                                    ->required()
+                                    ->maxLength(80),
+                                TextInput::make('postcode')
+                                    ->required()
+                                    ->maxLength(10),
+                                Select::make('state_id')
+                                    ->relationship('state', 'name')
+                                    ->searchable()
+                                    ->preload()
+                                    ->required()
+                                    ->label('State'),
+                                TextInput::make('country_code')
+                                    ->default('MY')
+                                    ->maxLength(2)
+                                    ->label('Country'),
+                                Toggle::make('is_primary')
+                                    ->label('Primary')
+                                    ->inline(false),
                             ]),
                     ]),
             ]);

--- a/app/Filament/Resources/Invoices/Schemas/InvoiceForm.php
+++ b/app/Filament/Resources/Invoices/Schemas/InvoiceForm.php
@@ -110,36 +110,27 @@ class InvoiceForm
                             ->relationship('items')
                             ->reorderable(false)
                             ->label('')
-                            ->itemLabel(function (array $state): string {
-                                /** @var string $description */
-                                $description = $state['description'] ?? '';
-
-                                return $description;
-                            })
                             ->schema([
-                                Grid::make(5)->schema([
-                                    TextInput::make('description')
-                                        ->required()
-                                        ->maxLength(255)
-                                        ->columnSpan(2),
-                                    TextInput::make('quantity')
-                                        ->required()
-                                        ->numeric()
-                                        ->minValue(1)
-                                        ->default(1),
-                                    TextInput::make('unit_price')
-                                        ->required()
-                                        ->numeric()
-                                        ->minValue(0)
-                                        ->prefix('RM'),
-                                    TextInput::make('tax_rate')
-                                        ->required()
-                                        ->numeric()
-                                        ->minValue(0)
-                                        ->maxValue(100)
-                                        ->default(0)
-                                        ->suffix('%'),
-                                ]),
+                                TextInput::make('description')
+                                    ->required()
+                                    ->maxLength(255),
+                                TextInput::make('quantity')
+                                    ->required()
+                                    ->numeric()
+                                    ->minValue(1)
+                                    ->default(1),
+                                TextInput::make('unit_price')
+                                    ->required()
+                                    ->numeric()
+                                    ->minValue(0)
+                                    ->prefix('RM'),
+                                TextInput::make('tax_rate')
+                                    ->required()
+                                    ->numeric()
+                                    ->minValue(0)
+                                    ->maxValue(100)
+                                    ->default(0)
+                                    ->suffix('%'),
                             ]),
                     ]),
 

--- a/app/Filament/Resources/Quotations/Schemas/QuotationForm.php
+++ b/app/Filament/Resources/Quotations/Schemas/QuotationForm.php
@@ -89,36 +89,27 @@ class QuotationForm
                             ->relationship('items')
                             ->reorderable(false)
                             ->label('')
-                            ->itemLabel(function (array $state): string {
-                                /** @var string $description */
-                                $description = $state['description'] ?? '';
-
-                                return $description;
-                            })
                             ->schema([
-                                Grid::make(5)->schema([
-                                    TextInput::make('description')
-                                        ->required()
-                                        ->maxLength(255)
-                                        ->columnSpan(2),
-                                    TextInput::make('quantity')
-                                        ->required()
-                                        ->numeric()
-                                        ->minValue(1)
-                                        ->default(1),
-                                    TextInput::make('unit_price')
-                                        ->required()
-                                        ->numeric()
-                                        ->minValue(0)
-                                        ->prefix('RM'),
-                                    TextInput::make('tax_rate')
-                                        ->required()
-                                        ->numeric()
-                                        ->minValue(0)
-                                        ->maxValue(100)
-                                        ->default(0)
-                                        ->suffix('%'),
-                                ]),
+                                TextInput::make('description')
+                                    ->required()
+                                    ->maxLength(255),
+                                TextInput::make('quantity')
+                                    ->required()
+                                    ->numeric()
+                                    ->minValue(1)
+                                    ->default(1),
+                                TextInput::make('unit_price')
+                                    ->required()
+                                    ->numeric()
+                                    ->minValue(0)
+                                    ->prefix('RM'),
+                                TextInput::make('tax_rate')
+                                    ->required()
+                                    ->numeric()
+                                    ->minValue(0)
+                                    ->maxValue(100)
+                                    ->default(0)
+                                    ->suffix('%'),
                             ]),
                     ]),
 


### PR DESCRIPTION
## Summary
- Convert form repeaters to table layout for improved data entry experience
- Affects Customers (addresses), Invoices (items), and Quotations (items)
- Removed Grid wrappers to enable Filament v4's automatic table rendering
- Removed itemLabel callbacks as table headers are now more descriptive

## Changes
- CustomerForm: Addresses repeater now displays as table (8 fields)
- InvoiceForm: Items repeater now displays as table (4 fields)  
- QuotationForm: Items repeater now displays as table (4 fields)

## Testing
- All 61 Filament resource tests passing
- PHPStan Level Max: 0 errors
- Code formatted with Pint

Closes #5