### PR TITLE
Fix repeater table layout with proper table() method implementation

### DIFF
--- a/app/Filament/Resources/Customers/Schemas/CustomerForm.php
+++ b/app/Filament/Resources/Customers/Schemas/CustomerForm.php
@@ -8,6 +8,7 @@ use App\Enums\CustomerType;
 use App\Enums\RiskLevel;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Repeater\TableColumn;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
@@ -59,6 +60,27 @@ class CustomerForm
                             ->reorderable(false)
                             ->minItems(1)
                             ->label('')
+                            ->table([
+                                TableColumn::make('Label')
+                                    ->width('100px'),
+                                TableColumn::make('Address Line 1')
+                                    ->markAsRequired(),
+                                TableColumn::make('Address Line 2'),
+                                TableColumn::make('City')
+                                    ->markAsRequired()
+                                    ->width('120px'),
+                                TableColumn::make('Postcode')
+                                    ->markAsRequired()
+                                    ->width('100px'),
+                                TableColumn::make('State')
+                                    ->markAsRequired()
+                                    ->width('120px'),
+                                TableColumn::make('Country')
+                                    ->width('90px'),
+                                TableColumn::make('Primary')
+                                    ->width('80px'),
+                            ])
+                            ->compact()
                             ->schema([
                                 TextInput::make('label')
                                     ->maxLength(50)

--- a/app/Filament/Resources/Invoices/Schemas/InvoiceForm.php
+++ b/app/Filament/Resources/Invoices/Schemas/InvoiceForm.php
@@ -8,6 +8,7 @@ use App\Enums\InvoiceStatus;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Repeater\TableColumn;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
@@ -110,6 +111,20 @@ class InvoiceForm
                             ->relationship('items')
                             ->reorderable(false)
                             ->label('')
+                            ->table([
+                                TableColumn::make('Description')
+                                    ->markAsRequired(),
+                                TableColumn::make('Quantity')
+                                    ->markAsRequired()
+                                    ->width('120px'),
+                                TableColumn::make('Unit Price')
+                                    ->markAsRequired()
+                                    ->width('140px'),
+                                TableColumn::make('Tax Rate')
+                                    ->markAsRequired()
+                                    ->width('120px'),
+                            ])
+                            ->compact()
                             ->schema([
                                 TextInput::make('description')
                                     ->required()

--- a/app/Filament/Resources/Quotations/Schemas/QuotationForm.php
+++ b/app/Filament/Resources/Quotations/Schemas/QuotationForm.php
@@ -7,6 +7,7 @@ namespace App\Filament\Resources\Quotations\Schemas;
 use App\Enums\QuotationStatus;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Repeater\TableColumn;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
@@ -89,6 +90,20 @@ class QuotationForm
                             ->relationship('items')
                             ->reorderable(false)
                             ->label('')
+                            ->table([
+                                TableColumn::make('Description')
+                                    ->markAsRequired(),
+                                TableColumn::make('Quantity')
+                                    ->markAsRequired()
+                                    ->width('120px'),
+                                TableColumn::make('Unit Price')
+                                    ->markAsRequired()
+                                    ->width('140px'),
+                                TableColumn::make('Tax Rate')
+                                    ->markAsRequired()
+                                    ->width('120px'),
+                            ])
+                            ->compact()
                             ->schema([
                                 TextInput::make('description')
                                     ->required()


### PR DESCRIPTION
## Summary
- Properly implement Filament v4 table repeaters using the table() method with TableColumn objects
- Previous PR #6 incorrectly assumed removing Grid wrappers would create table layout

## The Problem

PR #6 removed Grid wrappers expecting automatic table layout, but Filament v4 requires explicit table() method with TableColumn definitions. Fields were displaying vertically stacked instead of in table format.

## The Solution

Implemented proper table repeater pattern according to Filament v4 documentation:
- Added table() method with TableColumn objects defining column headers
- Added compact() for better space utilization
- Set appropriate column widths for numeric/narrow fields
- Marked required fields in table headers with markAsRequired()
- Imported Filament\Forms\Components\Repeater\TableColumn

## Changes

### InvoiceForm.php
- 4 columns: Description, Quantity (120px), Unit Price (140px), Tax Rate (120px)
- Compact table layout

### QuotationForm.php  
- 4 columns: Description, Quantity (120px), Unit Price (140px), Tax Rate (120px)
- Compact table layout

### CustomerForm.php
- 8 columns: Label (100px), Line1, Line2, City (120px), Postcode (100px), State (120px), Country (90px), Primary (80px)
- Compact table layout with optimized column widths

## Testing
- All 61 Filament resource tests passing (379 assertions)
- PHPStan Level Max: 0 errors
- Code formatted with Pint

Fixes #7