### PR TITLE
Simplify invoice form by consolidating payment fields

### DIFF
--- a/app/Filament/Resources/Invoices/Schemas/InvoiceForm.php
+++ b/app/Filament/Resources/Invoices/Schemas/InvoiceForm.php
@@ -48,13 +48,6 @@ class InvoiceForm
                             DateTimePicker::make('due_at')
                                 ->required()
                                 ->default(now()->addDays(30)),
-                        ]),
-                    ]),
-
-                Section::make('Payment Details')
-                    ->columnSpan(2)
-                    ->schema([
-                        Grid::make(2)->schema([
                             DateTimePicker::make('paid_at')
                                 ->label('Payment Date')
                                 ->visible(fn (callable $get): bool => $get('status') === InvoiceStatus::Paid->value)


### PR DESCRIPTION
## Summary
- Remove the separate Payment Details section
- Consolidate all payment fields into the Invoice Details section
- Maintain conditional visibility (fields only appear when status = Paid)

## Problem

The Payment Details section was unnecessary after we simplified payment tracking. Having a separate section for payment fields created visual clutter and made the form less intuitive.

## Solution

Moved all payment-related fields from the Payment Details section into the Invoice Details section:
- Payment Date (paid_at)
- Payment Method (payment_method_id)  
- Payment Reference (payment_reference)
- Payment Receipt (payment_receipt_path)

All fields maintain their conditional visibility rules - they only appear when invoice status is set to Paid.

## Benefits

- **Cleaner UI**: One less section to manage
- **Better grouping**: All invoice-related information in one place
- **More intuitive**: Payment details are invoice details
- **Consistent**: Aligns with simplified payment tracking model
- **Less clutter**: Streamlined form with fewer visual breaks

## Before
- Invoice Details section (5 fields)
- Payment Details section (4 fields) - separate section
- Summary section
- Invoice Items section
- Additional Information section

## After  
- Invoice Details section (9 fields, 4 conditionally visible)
- Summary section
- Invoice Items section
- Additional Information section

## Testing
- All 20 invoice Filament tests passing (121 assertions)
- PHPStan Level Max: 0 errors
- Code formatted with Pint
- All payment validation rules still work correctly

Closes #9